### PR TITLE
Update setup.py install_requires to use headless version of OpenCV.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=['certifi','chardet','click','easydict',
                       'h5py~=2.7','intel-openmp','imgaug',
                       'ipython','ipython-genutils',
-                      'matplotlib==3.0.3','moviepy<=1.0.1','numpy==1.16.4','opencv-python~=3.4',
+                      'matplotlib==3.0.3','moviepy<=1.0.1','numpy==1.16.4','opencv-python-headless~=3.4',
                       'pandas','patsy','python-dateutil','pyyaml>=5.1','requests',
                       'ruamel.yaml~=0.15','setuptools','scikit-image','scikit-learn',
                       'scipy','six','statsmodels','tables',


### PR DESCRIPTION
Currently `setup.py` brings in a version of the PyPI OpenCV package that assumes the presence of X11 (see https://github.com/skvark/opencv-python/issues/44).  This patch causes it to require the headless variant of the PyPI OpenCV package instead.