### PR TITLE
Assume headless is equivalent to DLClight

### DIFF
--- a/deeplabcutcore/generate_training_dataset/trainingsetmanipulation.py
+++ b/deeplabcutcore/generate_training_dataset/trainingsetmanipulation.py
@@ -19,12 +19,8 @@ import platform
 from functools import lru_cache
 
 
-if os.environ.get('DLClight', default=False) == 'True':
-    mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
-elif platform.system() == 'Darwin':
-    mpl.use('WxAgg') #TkAgg
-else:
-    mpl.use('TkAgg')
+# assume headless == DLClight
+mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
 import matplotlib.pyplot as plt
 from skimage import io
 

--- a/deeplabcutcore/pose_estimation_tensorflow/util/visualize.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/util/visualize.py
@@ -8,14 +8,12 @@ import numpy as np
 #from scipy.misc import imresize
 from deeplabcutcore.utils.auxfun_videos import imresize
 
-import matplotlib
+import matplotlib as mpl
 import platform
-if os.environ.get('DLClight', default=False) == 'True':
-    matplotlib.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
-elif platform.system() == 'Darwin':
-    matplotlib.use('WxAgg') #TkAgg
-else:
-    matplotlib.use('TkAgg')
+
+
+# assume headless == DLClight
+mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
 import matplotlib.pyplot as plt
 
 def _npcircle(image, cx, cy, radius, color, transparency=0.0):

--- a/deeplabcutcore/utils/make_labeled_video.py
+++ b/deeplabcutcore/utils/make_labeled_video.py
@@ -26,12 +26,8 @@ from pathlib import Path
 import platform
 
 import matplotlib as mpl
-if os.environ.get('DLClight', default=False) == 'True':
-    mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
-elif platform.system() == 'Darwin':
-    mpl.use('WxAgg') #TkAgg
-else:
-    mpl.use('TkAgg')
+# assume headless == DLClight
+mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
 import matplotlib.pyplot as plt
 
 from deeplabcutcore.utils import auxiliaryfunctions

--- a/deeplabcutcore/utils/visualization.py
+++ b/deeplabcutcore/utils/visualization.py
@@ -14,13 +14,9 @@ import numpy as np
 import matplotlib as mpl
 import platform
 from pathlib import Path
-if os.environ.get('DLClight', default=False) == 'True':
-    mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
-    pass
-elif platform.system() == 'Darwin':
-    mpl.use('WXAgg')
-else:
-    mpl.use('TkAgg') #TkAgg
+
+# assume headless == DLClight
+mpl.use('AGG') #anti-grain geometry engine #https://matplotlib.org/faq/usage_faq.html
 import matplotlib.pyplot as plt
 from deeplabcutcore.utils.auxiliaryfunctions import attempttomakefolder
 from matplotlib.collections import LineCollection


### PR DESCRIPTION
We ran into the same [MPL backend issue ](https://github.com/DeepLabCut/DeepLabCut/issues/597) (TkAgg in our case) on our cluster. Using `export DLClight=True` worked for us as a work-around. For many reasons we'd prefer not to rely on users adding an environment variable. It seems simple enough to assume that headless DLC should be equivalent to the current DLClight, which defaults to MPL backend AGG.