### PR TITLE
tf2.2alpha: export model

### DIFF
--- a/deeplabcutcore/pose_estimation_tensorflow/export.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/export.py
@@ -17,10 +17,11 @@ import tarfile
 
 import tensorflow as tf
 vers = (tf.__version__).split('.')
-if int(vers[0]) == 1 and int(vers[1]) > 12:
-    TF = tf.compat.v1
+if int(vers[0])==2 or int(vers[0])==1 and int(vers[1])>12:
+    TF=tf.compat.v1
 else:
-    TF = tf
+    TF=tf
+
 from tensorflow.python.tools import freeze_graph
 
 from deeplabcutcore.utils import auxiliaryfunctions
@@ -165,7 +166,7 @@ def load_model(cfg, shuffle=1, trainingsetindex=0, TFGPUinference=True,modelpref
         else:
             output = ['Sigmoid', 'pose/part_pred/block4/BiasAdd']
 
-    input = tf.compat.v1.get_default_graph().get_operations()[0].name
+    input = TF.get_default_graph().get_operations()[0].name
 
     return sess, input, output, dlc_cfg_train
 
@@ -197,21 +198,46 @@ def tf_to_pb(sess, checkpoint, output, output_dir=None):
 
     # save graph to pbtxt file
     pbtxt_file = os.path.normpath(output_dir + '/' + ckpt_base + '.pbtxt')
-    tf.io.write_graph(sess.graph.as_graph_def(), '', pbtxt_file, as_text=True)
+    TF.io.write_graph(sess.graph.as_graph_def(), '', pbtxt_file, as_text=True)
 
     # create frozen graph from pbtxt file
     pb_file = os.path.normpath(output_dir + '/' + ckpt_base + '.pb')
 
-    freeze_graph.freeze_graph(input_graph=pbtxt_file,
-                              input_saver='',
-                              input_binary=False,
-                              input_checkpoint=checkpoint,
-                              output_node_names=",".join(output),
-                              restore_op_name="save/restore_all",
-                              filename_tensor_name="save/Const:0",
-                              output_graph=pb_file,
-                              clear_devices=True,
-                              initializer_nodes='')
+    if int(vers[0])==2:
+
+        pb_file = os.path.normpath(output_dir + '/' + ckpt_base + '.pb')
+
+        frozen_graph_def = TF.graph_util.convert_variables_to_constants(
+            sess,
+            sess.graph_def,
+            output)
+
+        with open(pb_file, 'wb') as f:
+            f.write(frozen_graph_def.SerializeToString())
+            
+    else:
+
+
+
+        freeze_graph.freeze_graph(input_graph=pbtxt_file,
+                                  input_saver='',
+                                  input_binary=False,
+                                  input_checkpoint=checkpoint,
+                                  output_node_names=",".join(output),
+                                  restore_op_name="save/restore_all",
+                                  filename_tensor_name="save/Const:0",
+                                  output_graph=pb_file,
+                                  clear_devices=True,
+                                  initializer_nodes='')
+
+    # frozen_graph_def = TF.graph_util.convert_variables_to_constants(
+    #     sess,
+    #     sess.graph_def,
+    #     ",".join(output))
+
+    # # Save the frozen graph to .pb file.
+    # with open(pb_file, 'wb') as f:
+    #     f.write(frozen_graph_def.SerializeToString())
 
 
 def export_model(cfg_path, shuffle=1, trainingsetindex=0, snapshotindex=None,

--- a/deeplabcutcore/pose_estimation_tensorflow/nnet/conv_blocks.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/nnet/conv_blocks.py
@@ -17,8 +17,11 @@ import contextlib
 import functools
 
 import tensorflow as tf
-
-slim = tf.slim
+vers = (tf.__version__).split('.')
+if int(vers[0]) == 2:
+    import tf_slim as slim
+else:
+    import tensorflow.contrib.slim as slim
 
 
 def _fixed_padding(inputs, kernel_size, rate=1):

--- a/deeplabcutcore/pose_estimation_tensorflow/nnet/mobilenet.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/nnet/mobilenet.py
@@ -23,8 +23,11 @@ import copy
 import os
 
 import tensorflow as tf
-slim = tf.slim
-
+vers = (tf.__version__).split('.')
+if int(vers[0]) == 2:
+    import tf_slim as slim
+else:
+    import tensorflow.contrib.slim as slim
 
 @slim.add_arg_scope
 def apply_activation(x, name=None, activation_fn=None):

--- a/deeplabcutcore/pose_estimation_tensorflow/nnet/mobilenet_v2.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/nnet/mobilenet_v2.py
@@ -30,13 +30,17 @@ import copy
 import functools
 
 import tensorflow as tf
+vers = (tf.__version__).split('.')
+if int(vers[0]) == 2:
+    import tf_slim as slim
+else:
+    import tensorflow.contrib.slim as slim
 
 #from nets.mobilenet import conv_blocks as ops
 #from nets.mobilenet import mobilenet as lib
 from deeplabcutcore.pose_estimation_tensorflow.nnet  import conv_blocks as ops
 from deeplabcutcore.pose_estimation_tensorflow.nnet  import mobilenet as lib
 
-slim = tf.slim
 op = lib.op
 
 expand_input = ops.expand_input_by_factor

--- a/deeplabcutcore/pose_estimation_tensorflow/nnet/pose_net_mobilenet.py
+++ b/deeplabcutcore/pose_estimation_tensorflow/nnet/pose_net_mobilenet.py
@@ -18,7 +18,11 @@ https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mo
 
 import functools
 import tensorflow as tf
-import tensorflow.contrib.slim as slim
+vers = (tf.__version__).split('.')
+if int(vers[0]) == 2:
+    import tf_slim as slim
+else:
+    import tensorflow.contrib.slim as slim
 
 from deeplabcutcore.pose_estimation_tensorflow.nnet import mobilenet_v2, mobilenet, conv_blocks
 from ..dataset.pose_dataset import Batch


### PR DESCRIPTION
- Update tf import in a few pose_estimation_tensorflow/nnet files
- Update import of tf_slim in a few pose_estimation_tensorflow/nnet files-- in tf2, tf_slim is now a separate package (I think this only applies to mobilenets?)
- Update tf_to_pb function in export_model -- in tf1, we use tensorflow's freeze_graph function, but this is throwing an error in tf2 (see tensorflow/tensorflow#24591). Instead, in tf2, we now export the model using convert_variables_to_constants.

Note :: the same tensorflow version must be used to export the model from DeepLabCut as is used to import the model in DeepLabCut-live!