### PR TITLE
Import version information into the module

### DIFF
--- a/deeplabcutcore/__init__.py
+++ b/deeplabcutcore/__init__.py
@@ -75,3 +75,5 @@ from deeplabcutcore.refine_training_dataset import (
     merge_datasets,
 )
 from deeplabcutcore.post_processing import filterpredictions, analyzeskeleton
+
+from deeplabcutcore.version import __version__, VERSION


### PR DESCRIPTION
One line fix to automatically import the `__version__` attribute [as in the main DLC package](https://github.com/DeepLabCut/DeepLabCut/blob/87e18282c0ea354780cbf16ddfed85869a887664/deeplabcut/__init__.py#L121) for consistency between the packages.

## Steps to repro

For `deeplabcutcore`, run:

``` python
try:
    import deeplabcut as dlc
except ModuleNotFoundError:
    import deeplabcutcore as dlc
import tensorflow as tf
print(f"Loaded DeepLabCut {dlc.__version__} for Tensorflow {tf.__version__}")
```

raises
```
Traceback (most recent call last):                                                 
  File "test.py", line 8, in <module>                                              
    print(f"Loaded DeepLabCut {dlc.__version__} for Tensorflow {tf.__version__}")  
AttributeError: module 'deeplabcutcore' has no attribute '__version__'             
```